### PR TITLE
[PR] Ensure feed categories are at least an empty array

### DIFF
--- a/includes/class-wnpa-external-source.php
+++ b/includes/class-wnpa-external-source.php
@@ -292,6 +292,11 @@ class WNPA_External_Source {
 				$visibility = $feed_item->get_item_tags( SIMPLEPIE_NAMESPACE_DC_11, 'accessRights' );
 				$categories = $feed_item->get_categories();
 
+				// SimplePie returns `null` rather than an empty array if no categories are found.
+				if ( ! $categories ) {
+					$categories = array();
+				}
+
 				$locations = $default_source_location;
 				$tags      = array();
 				// Split the provided categories into tags and locations.


### PR DESCRIPTION
This avoids a notice when no categories are provided in a feed and SimplePie returns `null`.

Fixes #63