### PR TITLE
[PR] Publish feed items as posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0 (TBD)
 
 * Rename plugin from WNPA Syndication to Publish Feed Items to better fit mission.
+* Deprecate the `wnpa_content_type` filter. Only one unused theme was using this. Feed items can become posts through the submit meta box now.
 
 ## 0.3.2 (April 9, 2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Rename plugin from WNPA Syndication to Publish Feed Items to better fit mission.
 * Deprecate the `wnpa_content_type` filter. Only one unused theme was using this. Feed items can become posts through the submit meta box now.
 * Introduce the `wsuwp_pfi_public_feed_items` filter. This allows opt-in public feed items.
+* Introduce the `wsuwp_pfi_default_post_status` filter. This allows the default post status of draft to be modified.
 
 ## 0.3.2 (April 9, 2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Rename plugin from WNPA Syndication to Publish Feed Items to better fit mission.
 * Deprecate the `wnpa_content_type` filter. Only one unused theme was using this. Feed items can become posts through the submit meta box now.
+* Introduce the `wsuwp_pfi_public_feed_items` filter. This allows opt-in public feed items.
 
 ## 0.3.2 (April 9, 2015)
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@ module.exports = function(grunt) {
 
         phpcs: {
             plugin: {
-                src: './'
+                src: [ "./*.php", "./includes/*.php" ]
             },
             options: {
                 bin: "vendor/bin/phpcs --extensions=php --ignore=\"*/vendor/*,*/node_modules/*\"",

--- a/css/feed-item.css
+++ b/css/feed-item.css
@@ -15,3 +15,7 @@
 #wnpa_item_visibility-tabs .hide-if-no-js {
 	display: none;
 }
+
+#post-body-content {
+	margin-bottom: 0;
+}

--- a/includes/class-wnpa-feed-item.php
+++ b/includes/class-wnpa-feed-item.php
@@ -89,8 +89,8 @@ class WNPA_Feed_Item {
 
 		$args = array(
 			'labels'             => $labels,
-			'public'             => true,
-			'publicly_queryable' => true,
+			'public'             => false,
+			'publicly_queryable' => false,
 			'show_ui'            => true,
 			'show_in_menu'       => true,
 			'query_var'          => true,
@@ -102,8 +102,19 @@ class WNPA_Feed_Item {
 			'taxonomies'         => array( 'post_tag', 'category' ),
 		);
 
-		register_post_type( $this->item_content_type, $args );
+		/**
+		 * Filter whether feed items should be public.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param bool $public Default false. True if feed items should be exposed at /feed-items/.
+		 */
+		if ( apply_filters( 'wsuwp_pfi_public_feed_items', false ) ) {
+			$args['public'] = true;
+			$args['publicly_queryable'] = true;
+		}
 
+		register_post_type( $this->item_content_type, $args );
 	}
 
 	/**

--- a/includes/class-wnpa-feed-item.php
+++ b/includes/class-wnpa-feed-item.php
@@ -567,7 +567,15 @@ class WNPA_Feed_Item {
 		$new_post = (array) $post;
 		unset( $new_post['ID'] );
 		$new_post['post_type'] = 'post';
-		$new_post['post_status'] = 'draft';
+
+		/**
+		 * Filter the default post_status of the corresponding post for a feed item.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $post_status Default 'draft'.
+		 */
+		$new_post['post_status'] = apply_filters( 'wsuwp_pfi_default_post_status', 'draft' );
 
 		$new_post_id = wp_insert_post( $new_post );
 

--- a/includes/class-wnpa-feed-item.php
+++ b/includes/class-wnpa-feed-item.php
@@ -63,15 +63,6 @@ class WNPA_Feed_Item {
 	 * feed items across multiple publishers.
 	 */
 	public function register_post_type() {
-		$default_post_type_slug = $this->item_content_type;
-
-		// Allow plugins or themes to override the default content type.
-		$this->item_content_type = apply_filters( 'wnpa_content_type', $this->item_content_type );
-
-		if ( $default_post_type_slug !== $this->item_content_type ) {
-			return;
-		}
-
 		$labels = array(
 			'name'               => 'Feed Items',
 			'singular_name'      => 'Feed Item',

--- a/includes/class-wnpa-feed-item.php
+++ b/includes/class-wnpa-feed-item.php
@@ -565,6 +565,7 @@ class WNPA_Feed_Item {
 		$new_post = (array) $post;
 		unset( $new_post['ID'] );
 		$new_post['post_type'] = 'post';
+		$new_post['post_status'] = 'draft';
 
 		$new_post_id = wp_insert_post( $new_post );
 

--- a/includes/class-wnpa-feed-item.php
+++ b/includes/class-wnpa-feed-item.php
@@ -452,14 +452,14 @@ class WNPA_Feed_Item {
 	}
 
 	/**
-	 * Retrieve the corresponding post ID of a feed item.
+	 * Retrieve the corresponding post ID of a feed item or post associated with a feed item.
 	 *
 	 * @since 1.0.0
 	 * @global wpdb $wpdb
 	 *
-	 * @param int $post_id ID of the feed item.
+	 * @param int $post_id ID of the feed item or post.
 	 *
-	 * @return int|bool The ID of the corresponding post if available. False if not.
+	 * @return int|bool The ID of the corresponding post or feed item if available. False if not.
 	 */
 	public static function get_feed_item_post_id( $post_id ) {
 		global $wpdb;

--- a/includes/class-wnpa-feed-item.php
+++ b/includes/class-wnpa-feed-item.php
@@ -98,7 +98,7 @@ class WNPA_Feed_Item {
 			'capability_type'    => 'post',
 			'has_archive'        => 'feed-items',
 			'hierarchical'       => false,
-			'supports'           => array( 'title', 'editor', 'excerpt', 'thumbnail' ),
+			'supports'           => array( 'thumbnail' ),
 			'taxonomies'         => array( 'post_tag', 'category' ),
 		);
 
@@ -165,8 +165,25 @@ class WNPA_Feed_Item {
 			return;
 		}
 
+		add_meta_box( 'wsuwp_pfi_feed_item_content', esc_html( $post->post_title ), array( $this, 'display_feed_item_content_meta_box' ), $this->item_content_type, 'normal' );
 		add_meta_box( 'wnpa_featured_item', 'Featured Article', array( $this, 'display_featured_item_meta_box' ), $this->item_content_type, 'normal' );
 		add_meta_box( 'wnpa_byline', 'Byline Information', array( $this, 'display_byline_meta_box' ), $this->item_content_type, 'normal' );
+	}
+
+	/**
+	 * Display the title and content from a feed item. This replaces the standard title
+	 * and editor meta boxes.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_Post $post
+	 */
+	public function display_feed_item_content_meta_box( $post ) {
+		?>
+		<div class="feed_item_content">
+			<?php echo apply_filters( 'the_content', wp_kses_post( $post->post_content ) ); ?>
+		</div>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
This changes the focus of the plugin quite a bit.

Instead of providing a `/feed-items/` slug with syndicated content, the feed items are only in the dashboard by default. Users can publish these feed items as posts using a checkbox in the submit meta box. This allows a group to sort through syndicated content before deciding what should be on the front page.

![screen shot 2016-04-06 at 11 44 43 am](https://cloud.githubusercontent.com/assets/286171/14328773/093e114a-fbed-11e5-97f9-5e6420655f12.png)
![screen shot 2016-04-06 at 11 44 59 am](https://cloud.githubusercontent.com/assets/286171/14328777/0bb71af2-fbed-11e5-8dac-109520964978.png)

Once a feed item is published as a post, a link appears to edit that corresponding post. The corresponding post is saved as a draft initially, so the user will need to publish that as well. This behavior can be filtered so that these posts are public by default instead.

Previously, we provided the ability to change the post type of feed items so that they could be published as posts by default. This has been removed. It was used in one theme at WSU for a project that did not get traction.