### PR TITLE
[PR] Provide more stable cron events

### DIFF
--- a/includes/class-publish-feed-items-activator.php
+++ b/includes/class-publish-feed-items-activator.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Fired during plugin activation.
+ *
+ * @since      1.0.0
+ */
+class Publish_Feed_Items_Activator {
+	/**
+	 * Setup the initial cron job to start checking external sources for new
+	 * feed items.
+	 *
+	 * @since    1.0.0
+	 */
+	public static function activate() {
+		wp_schedule_event( time(), 'hourly', 'publish_feed_items_consume_sources' );
+	}
+}

--- a/includes/class-publish-feed-items-deactivator.php
+++ b/includes/class-publish-feed-items-deactivator.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Fired during plugin deactivation.
+ *
+ * @since      1.0.0
+ */
+class Publish_Feed_Items_Deactivator {
+	/**
+	 * Remove the cron hook used to check external sources for new feed items.
+	 *
+	 * @since    1.0.0
+	 */
+	public static function deactivate() {
+		wp_clear_scheduled_hook( 'publish_feed_items_consume_sources' );
+	}
+}

--- a/includes/class-wnpa-external-source.php
+++ b/includes/class-wnpa-external-source.php
@@ -18,39 +18,17 @@ class WNPA_External_Source {
 	var $source_url_meta_key = '_wnpa_source_url';
 
 	/**
-	 * @var string Hook used when firing our source consumption cron event.
-	 */
-	var $source_cron_hook    = 'wnpa_consume_source';
-
-	/**
 	 * Add hooks as the class is initialized.
 	 */
 	public function __construct() {
-		register_activation_hook( dirname( dirname( __FILE__ ) ) . '/wnpa-syndication.php', array( $this, 'activate' ) );
-		register_deactivation_hook( dirname( dirname( __FILE__ ) ) . '/wnpa-syndication.php', array( $this, 'deactivate' ) );
-
 		add_action( 'init', array( $this, 'register_post_type' ) );
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 10, 2 );
 		add_action( 'save_post', array( $this, 'save_post' ), 10, 2 );
 
 		// Use the custom hook setup to handle our cron action.
-		add_action( $this->source_cron_hook, array( $this, 'batch_external_sources' ) );
+		add_action( 'publish_feed_items_consume_sources', array( $this, 'batch_external_sources' ) );
 
 		add_filter( 'bulk_post_updated_messages', array( $this, 'bulk_post_updated_message' ), 10, 2 );
-	}
-
-	/**
-	 * Perform tasks that should occur only on plugin activation.
-	 */
-	public function activate() {
-		wp_schedule_event( time(), 'hourly', $this->source_cron_hook );
-	}
-
-	/**
-	 * Perform tasks that should occur only on plugin deactivation.
-	 */
-	public function deactivate() {
-		wp_clear_scheduled_hook( $this->source_cron_hook );
 	}
 
 	/**

--- a/includes/class-wnpa-external-source.php
+++ b/includes/class-wnpa-external-source.php
@@ -159,6 +159,15 @@ class WNPA_External_Source {
 			return;
 		}
 
+		/**
+		 * If we've lost the cron event scheduled to consume external sources, then start
+		 * it up again 30 seconds in the future to account for the immediate consumption
+		 * of this new external source.
+		 */
+		if ( false === wp_next_scheduled( 'publish_feed_items_consume_sources' ) ) {
+			wp_schedule_event( time() + 30, 'hourly', 'publish_feed_items_consume_sources' );
+		}
+
 		$external_source_url = $_POST['wnpa_source_url'];
 
 		// Attempt a HEAD request to the specified URL for current status info.

--- a/wnpa-syndication.php
+++ b/wnpa-syndication.php
@@ -14,6 +14,29 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+/**
+ * Code that runs during activation of the plugin.
+ *
+ * @since 1.0.0
+ */
+function activate_publish_feed_items() {
+	require_once dirname( __FILE__ ) . '/includes/class-publish-feed-items-activator.php';
+	Publish_Feed_Items_Activator::activate();
+}
+
+/**
+ * Code that runs during deactivation of the plugin.
+ *
+ * @since 1.0.0
+ */
+function deactivate_publish_feed_items() {
+	require_once dirname( __FILE__ ) . '/includes/class-publish-feed-items-deactivator.php';
+	Publish_Feed_Items_Deactivator::deactivate();
+}
+
+register_activation_hook( __FILE__, 'activate_publish_feed_items' );
+register_deactivation_hook( __FILE__, 'deactivate_publish_feed_items' );
+
 // The core plugin class.
 require dirname( __FILE__ ) . '/includes/class-wsuwp-publish-feed-items.php';
 

--- a/wnpa-syndication.php
+++ b/wnpa-syndication.php
@@ -15,21 +15,36 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 /**
- * Code that runs during activation of the plugin.
+ * Code that runs during activation of the plugin on an individual site.
+ *
+ * If the plugin is network activated, we can't rely on this activate code to properly
+ * setup cron events for all sites on the network and instead rely on other code.
  *
  * @since 1.0.0
+ *
+ * @param bool $network_wide True if the plugin is network activated. False if not.
  */
-function activate_publish_feed_items() {
+function activate_publish_feed_items( $network_wide ) {
+	if ( true === $network_wide ) {
+		return;
+	}
+
 	require_once dirname( __FILE__ ) . '/includes/class-publish-feed-items-activator.php';
 	Publish_Feed_Items_Activator::activate();
 }
 
 /**
- * Code that runs during deactivation of the plugin.
+ * Code that runs during deactivation of the plugin on an individual site.
  *
  * @since 1.0.0
+ *
+ * @param bool $network_wide True if the plugin is network deactivated. False if not.
  */
-function deactivate_publish_feed_items() {
+function deactivate_publish_feed_items( $network_wide ) {
+	if ( true === $network_wide ) {
+		return;
+	}
+
 	require_once dirname( __FILE__ ) . '/includes/class-publish-feed-items-deactivator.php';
 	Publish_Feed_Items_Deactivator::deactivate();
 }


### PR DESCRIPTION
Previously, the activate and deactivation hooks were in a place that may not have worked before and definitely doesn't work in the new structure of the plugin.

This replaces that behavior by providing specific activation and deactivation functions to setup the cron event that checks external sources for new feed items.

It also adds a fallback when saving an external source to check that an existing cron is available.